### PR TITLE
Skip motion vector shader if depth texture does not include MotionVec…

### DIFF
--- a/Assets/DrawMeshWithMotionVectors.cs
+++ b/Assets/DrawMeshWithMotionVectors.cs
@@ -35,6 +35,11 @@ public class DrawMeshWithMotionVectors: MonoBehaviour
 
     void OnRenderObject()
     {
+        if ((Camera.current.depthTextureMode & DepthTextureMode.MotionVectors) == 0)
+        {
+            return;
+        }
+    
         _motionVectorMaterial.SetMatrix("_PreviousM", _previousModelMatrix);
         _motionVectorMaterial.SetMatrix("_PreviousVP", CameraMatrixProvider.GetPreviousVPMatrix(Camera.current));
         _motionVectorMaterial.SetMatrix("_NonJitteredVP", CameraMatrixProvider.GetVPMatrix(Camera.current));


### PR DESCRIPTION
…tors

Prevents motion vectors appearing in the color buffer if camera doesn't have motion vector buffer enabled